### PR TITLE
Print View is Mobile - Hid Add Notes

### DIFF
--- a/templates/internshipView.tpl
+++ b/templates/internshipView.tpl
@@ -569,7 +569,7 @@
 
   <div class="row">
     <div class="col-lg-6">
-      <div class="form-group">
+      <div class="form-group print-hide">
         <label for="{NOTES_ID}">Add a note</label> {NOTES}
       </div>
       <div class="form-group">


### PR DESCRIPTION
Hid the add notes box from being rendered when printed. #169 