### PR TITLE
Undefined fields when removing admin

### DIFF
--- a/javascript/editAdmin/editAdmin.jsx
+++ b/javascript/editAdmin/editAdmin.jsx
@@ -36,7 +36,7 @@ var DepartmentList = React.createClass({
 
 var DeleteAdmin = React.createClass({
 	handleChange: function() {
-		this.props.onAdminDelete(this.props.id);
+		this.props.onAdminDelete(this.props.id, this.props.username, this.props.department);
 	},
 	render: function() {
 		return (


### PR DESCRIPTION
#339 A call to onAdminDelete was not sending all the required variables.